### PR TITLE
Fix: CronExpression.swift:34:396: Static let 'DefaultValue' is intern…

### DIFF
--- a/Sources/CronRepresentation.swift
+++ b/Sources/CronRepresentation.swift
@@ -19,7 +19,7 @@ enum CronField: Int {
 
 public struct CronRepresentation {
 	static let NumberOfComponentsInValidString = 6
-	static let DefaultValue = "*"
+	public static let DefaultValue = "*"
 	static let StepIdentifier = "/"
 	static let ListIdentifier = ","
     static let RangeIdentifier = "-"


### PR DESCRIPTION
It looks like an issue about swift 4, "Swift 4 doesn't allow private constants as default arguments of internal functions in frameworks".