### PR TITLE
Fixed: init?(cronString: String) to accept expression without the year field.

### DIFF
--- a/Sources/CronRepresentation.swift
+++ b/Sources/CronRepresentation.swift
@@ -18,7 +18,7 @@ enum CronField: Int {
 }
 
 public struct CronRepresentation {
-	static let NumberOfComponentsInValidString = 6
+	static let NumberOfComponentsInValidString = 5
 	public static let DefaultValue = "*"
 	static let StepIdentifier = "/"
 	static let ListIdentifier = ","
@@ -65,7 +65,7 @@ public struct CronRepresentation {
 			return nil
 		}
 
-		self.init(minute: parts[0], hour: parts[1], day: parts[2], month: parts[3], weekday: parts[4], year: parts[5])
+        self.init(minute: parts[0], hour: parts[1], day: parts[2], month: parts[3], weekday: parts[4], year: parts.indices.contains(5) ? parts[5] : CronRepresentation.DefaultValue)
 	}
 
 	// MARK: Issue 3: pass in enum. Get value out of enum and check if it matches the default value?


### PR DESCRIPTION
The init?(cronString: String) will now be able to accept expressions like "* * * * *" which translates to “At every minute" in standard cron.
It makes no difference to everything else in the repo, but will allow other uses for this library.